### PR TITLE
Feature/cover image browser

### DIFF
--- a/components/CoverImageBrowser.vue
+++ b/components/CoverImageBrowser.vue
@@ -45,15 +45,15 @@ export default {
     }
   },
   mounted() {
-    this.generateInternalOptions()
+    this.setInternalOptions()
 
     // select default options
-    const indexes = this.generateRandomIndexes(this.selectLimit, this.internalOptions.length)
+    const indexes = this.getRandomIndexes(this.selectLimit, this.internalOptions.length)
     const options = indexes.map(index => this.internalOptions[index])
     this.select(options)
   },
   methods: {
-    generateRandomIndexes(amount, range) {
+    getRandomIndexes(amount, range) {
       var indexes = []
       while(indexes.length < amount) {
         var index = Math.floor(Math.random() * range)
@@ -62,16 +62,16 @@ export default {
       }
       return indexes
     },
-    generateInternalOptions() {
+    setInternalOptions() {
       const options = Array.isArray(this.options) ? this.options : defaultOptions
-      const indexes = this.generateRandomIndexes(this.optionsAmount, options.length)
+      const indexes = this.getRandomIndexes(this.optionsAmount, options.length)
       this.internalOptions = indexes.map(index => options[index])
     },
     reload() {
       if(this.reloading.state !== STATES.DEFAULT) return
 
       this.reloading.state = STATES.LOADING
-      this.generateInternalOptions()
+      this.setInternalOptions()
       this.reloading.state = STATES.SUCCESS
       this.reloading.message = 'reload成功'
     },

--- a/components/CoverImageBrowser.vue
+++ b/components/CoverImageBrowser.vue
@@ -1,8 +1,8 @@
 <template>
 <div class="cover-image-browser">
   <div class="options tcl-container">
-    <div class="tcl-panel" v-for="option of internalOptions" :key="option">
-      <cover-image :url="option" :classes="['option']" :width="4" @click.native="select(option)"></cover-image>
+    <div v-for="option of internalOptions" :key="option" :class="['tcl-panel', isSelected(option) ? 'active' : '']">
+      <cover-image :url="option" :width="4" @click.native="select(option)"></cover-image>
     </div>
   </div>
   <submit-button label='reload' :state.sync='reloading.state' :message.sync='reloading.message' @click.native='reload'></submit-button>
@@ -79,7 +79,7 @@ export default {
       var newSelecteds = this.selectedOptions
       if(!Array.isArray(options)) options = [options]
       for(var option of options) {
-        if(this.selectedOptions.indexOf(option) > -1) {
+        if(this.isSelected(option)) {
           const index = this.selectedOptions.findIndex(_option => _option === option)
           newSelecteds.splice(index, 1)
         } else {
@@ -88,6 +88,9 @@ export default {
         }
       }
       this.$emit('update:selectedOptions', newSelecteds)
+    },
+    isSelected(option) {
+      return this.selectedOptions.indexOf(option) > -1
     }
   },
   components: {
@@ -99,5 +102,13 @@ export default {
 
 <style lang="scss">
 @import '~watchout-common-assets/styles/resources';
+
+.cover-image-browser {
+  > .options {
+    > .active {
+      border: 1px solid black; //TODO
+    }
+  }
+}
 
 </style>

--- a/components/CoverImageBrowser.vue
+++ b/components/CoverImageBrowser.vue
@@ -44,10 +44,8 @@ export default {
 
     // select default options
     const indexes = this.generateRandomIndexes(this.selectLimit, this.internalOptions.length)
-    for(var index of indexes) {
-      var option = this.internalOptions[index]
-      this.select(option)
-    }
+    const options = indexes.map(index => this.internalOptions[index])
+    this.select(options)
   },
   methods: {
     generateRandomIndexes(amount, range) {
@@ -72,14 +70,17 @@ export default {
       this.reloading.state = STATES.SUCCESS
       this.reloading.message = 'reload成功'
     },
-    select(option) {
+    select(options) {
       var newSelecteds = this.selectedOptions
-      if(this.selectedOptions.indexOf(option) > -1) {
-        const index = this.selectedOptions.findIndex(_option => _option === option)
-        newSelecteds.splice(index, 1)
-      } else {
-        if(this.selectedOptions.length === this.selectLimit) return
-        newSelecteds.push(option)
+      if(!Array.isArray(options)) options = [options]
+      for(var option of options) {
+        if(this.selectedOptions.indexOf(option) > -1) {
+          const index = this.selectedOptions.findIndex(_option => _option === option)
+          newSelecteds.splice(index, 1)
+        } else {
+          if(this.selectedOptions.length === this.selectLimit) return
+          newSelecteds.push(option)
+        }
       }
       this.$emit('update:selectedOptions', newSelecteds)
     }

--- a/components/CoverImageBrowser.vue
+++ b/components/CoverImageBrowser.vue
@@ -3,10 +3,14 @@
   <div class="options" v-for="option of internalOptions">
     {{ option }}
   </div>
+  <submit-button label='reload' :state.sync='reloading.state' :message.sync='reloading.message' @click.native='reload'></submit-button>
 </div>
 </template>
 
 <script>
+import SubmitButton from './button/Submit'
+import * as STATES from '../lib/states'
+
 const defaultOptions = [
   'watchout-common-assets/images/cover-images/1.jpeg',
   'watchout-common-assets/images/cover-images/2.jpeg',
@@ -21,7 +25,11 @@ export default {
   props: ['limit', 'selectedOptions', 'options'],
   data() {
     return {
-      internalOptions: []
+      internalOptions: [],
+      reloading: {
+        state: STATES.DEFAULT,
+        message: null
+      }
     }
   },
   mounted() {
@@ -37,7 +45,18 @@ export default {
         indexes.push(index)
       }
       this.internalOptions = indexes.map(index => options[index])
+    },
+    reload() {
+      if(this.reloading.state !== STATES.DEFAULT) return
+
+      this.reloading.state = STATES.LOADING
+      this.selectOptions()
+      this.reloading.state = STATES.SUCCESS
+      this.reloading.message = 'reload成功'
     }
+  },
+  components: {
+    SubmitButton
   }
 }
 </script>

--- a/components/CoverImageBrowser.vue
+++ b/components/CoverImageBrowser.vue
@@ -8,19 +8,35 @@
 
 <script>
 const defaultOptions = [
-  'watchout-common-assets/images/cover-images/1.png',
-  'watchout-common-assets/images/cover-images/2.png',
-  'watchout-common-assets/images/cover-images/3.png',
-  'watchout-common-assets/images/cover-images/4.png',
-  'watchout-common-assets/images/cover-images/5.png',
-  'watchout-common-assets/images/cover-images/6.png'
+  'watchout-common-assets/images/cover-images/1.jpeg',
+  'watchout-common-assets/images/cover-images/2.jpeg',
+  'watchout-common-assets/images/cover-images/3.jpeg',
+  'watchout-common-assets/images/cover-images/4.jpeg',
+  'watchout-common-assets/images/cover-images/5.jpg',
+  'watchout-common-assets/images/cover-images/6.jpeg'
 ]
+const optionsAmt = 4
 
 export default {
   props: ['limit', 'selectedOptions', 'options'],
-  computed: {
-    internalOptions() {
-      return Array.isArray(this.options) ? this.options : defaultOptions
+  data() {
+    return {
+      internalOptions: []
+    }
+  },
+  mounted() {
+    this.selectOptions()
+  },
+  methods: {
+    selectOptions() {
+      const options = Array.isArray(this.options) ? this.options : defaultOptions
+      var indexes = []
+      while(indexes.length < optionsAmt) {
+        var index = Math.floor(Math.random() * options.length)
+        if (indexes.indexOf(index) > -1) continue
+        indexes.push(index)
+      }
+      this.internalOptions = indexes.map(index => options[index])
     }
   }
 }

--- a/components/CoverImageBrowser.vue
+++ b/components/CoverImageBrowser.vue
@@ -1,7 +1,9 @@
 <template>
 <div class="cover-image-browser">
-  <div class="options">
-    <cover-image v-for="option of internalOptions" :key="option" :url="option" @click.native="select(option)" width="4"></cover-image>
+  <div class="options tcl-container">
+    <div class="tcl-panel" v-for="option of internalOptions" :key="option">
+      <cover-image :url="option" :classes="['option']" :width="4" @click.native="select(option)"></cover-image>
+    </div>
   </div>
   <submit-button label='reload' :state.sync='reloading.state' :message.sync='reloading.message' @click.native='reload'></submit-button>
 </div>

--- a/components/CoverImageBrowser.vue
+++ b/components/CoverImageBrowser.vue
@@ -23,10 +23,10 @@ const defaultOptions = [
   'cover-images/6.png'
 ]
 const defaultLimit = 1
-const optionsAmount = 4
+const defaultAmount = 4
 
 export default {
-  props: ['limit', 'selectedOptions', 'options'],
+  props: ['limit', 'amount', 'selectedOptions', 'options'],
   data() {
     return {
       internalOptions: [],
@@ -39,6 +39,9 @@ export default {
   computed: {
     selectLimit() {
       return typeof this.limit === 'number' ? this.limit : defaultLimit
+    },
+    optionsAmount() {
+      return typeof this.amount === 'number' ? this.amount : defaultAmount
     }
   },
   mounted() {
@@ -61,7 +64,7 @@ export default {
     },
     generateInternalOptions() {
       const options = Array.isArray(this.options) ? this.options : defaultOptions
-      const indexes = this.generateRandomIndexes(optionsAmount, options.length)
+      const indexes = this.generateRandomIndexes(this.optionsAmount, options.length)
       this.internalOptions = indexes.map(index => options[index])
     },
     reload() {

--- a/components/CoverImageBrowser.vue
+++ b/components/CoverImageBrowser.vue
@@ -1,24 +1,26 @@
 <template>
 <div class="cover-image-browser">
-  <div class="options" v-for="option of internalOptions">
-    {{ option }}
+  <div class="options">
+    <cover-image v-for="option of internalOptions" :key="option" :url="option" @click.native="select(option)" width="4"></cover-image>
   </div>
   <submit-button label='reload' :state.sync='reloading.state' :message.sync='reloading.message' @click.native='reload'></submit-button>
 </div>
 </template>
 
 <script>
-import SubmitButton from './button/Submit'
 import * as STATES from '../lib/states'
+import SubmitButton from './button/Submit'
+import CoverImage from './CoverImage'
 
 const defaultOptions = [
-  'watchout-common-assets/images/cover-images/1.jpeg',
-  'watchout-common-assets/images/cover-images/2.jpeg',
-  'watchout-common-assets/images/cover-images/3.jpeg',
-  'watchout-common-assets/images/cover-images/4.jpeg',
-  'watchout-common-assets/images/cover-images/5.jpg',
-  'watchout-common-assets/images/cover-images/6.jpeg'
+  'cover-images/1.png',
+  'cover-images/2.png',
+  'cover-images/3.png',
+  'cover-images/4.png',
+  'cover-images/5.png',
+  'cover-images/6.png'
 ]
+const defaultLimit = 1
 const optionsAmount = 4
 
 export default {
@@ -32,31 +34,59 @@ export default {
       }
     }
   },
+  computed: {
+    selectLimit() {
+      return typeof this.limit === 'number' ? this.limit : defaultLimit
+    }
+  },
   mounted() {
-    this.generateOptions()
+    this.generateInternalOptions()
+
+    // select default options
+    const indexes = this.generateRandomIndexes(this.selectLimit, this.internalOptions.length)
+    for(var index of indexes) {
+      var option = this.internalOptions[index]
+      this.select(option)
+    }
   },
   methods: {
-    generateOptions() {
-      const options = Array.isArray(this.options) ? this.options : defaultOptions
+    generateRandomIndexes(amount, range) {
       var indexes = []
-      while(indexes.length < optionsAmount) {
-        var index = Math.floor(Math.random() * options.length)
+      while(indexes.length < amount) {
+        var index = Math.floor(Math.random() * range)
         if (indexes.indexOf(index) > -1) continue
         indexes.push(index)
       }
+      return indexes
+    },
+    generateInternalOptions() {
+      const options = Array.isArray(this.options) ? this.options : defaultOptions
+      const indexes = this.generateRandomIndexes(optionsAmount, options.length)
       this.internalOptions = indexes.map(index => options[index])
     },
     reload() {
       if(this.reloading.state !== STATES.DEFAULT) return
 
       this.reloading.state = STATES.LOADING
-      this.generateOptions()
+      this.generateInternalOptions()
       this.reloading.state = STATES.SUCCESS
       this.reloading.message = 'reload成功'
+    },
+    select(option) {
+      var newSelecteds = this.selectedOptions
+      if(this.selectedOptions.indexOf(option) > -1) {
+        const index = this.selectedOptions.findIndex(_option => _option === option)
+        newSelecteds.splice(index, 1)
+      } else {
+        if(this.selectedOptions.length === this.selectLimit) return
+        newSelecteds.push(option)
+      }
+      this.$emit('update:selectedOptions', newSelecteds)
     }
   },
   components: {
-    SubmitButton
+    SubmitButton,
+    CoverImage
   }
 }
 </script>

--- a/components/CoverImageBrowser.vue
+++ b/components/CoverImageBrowser.vue
@@ -1,0 +1,32 @@
+<template>
+<div class="cover-image-browser">
+  <div class="options" v-for="option of internalOptions">
+    {{ option }}
+  </div>
+</div>
+</template>
+
+<script>
+const defaultOptions = [
+  'watchout-common-assets/images/cover-images/1.png',
+  'watchout-common-assets/images/cover-images/2.png',
+  'watchout-common-assets/images/cover-images/3.png',
+  'watchout-common-assets/images/cover-images/4.png',
+  'watchout-common-assets/images/cover-images/5.png',
+  'watchout-common-assets/images/cover-images/6.png'
+]
+
+export default {
+  props: ['limit', 'selectedOptions', 'options'],
+  computed: {
+    internalOptions() {
+      return Array.isArray(this.options) ? this.options : defaultOptions
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+@import '~watchout-common-assets/styles/resources';
+
+</style>

--- a/components/CoverImageBrowser.vue
+++ b/components/CoverImageBrowser.vue
@@ -19,7 +19,7 @@ const defaultOptions = [
   'watchout-common-assets/images/cover-images/5.jpg',
   'watchout-common-assets/images/cover-images/6.jpeg'
 ]
-const optionsAmt = 4
+const optionsAmount = 4
 
 export default {
   props: ['limit', 'selectedOptions', 'options'],
@@ -33,13 +33,13 @@ export default {
     }
   },
   mounted() {
-    this.selectOptions()
+    this.generateOptions()
   },
   methods: {
-    selectOptions() {
+    generateOptions() {
       const options = Array.isArray(this.options) ? this.options : defaultOptions
       var indexes = []
-      while(indexes.length < optionsAmt) {
+      while(indexes.length < optionsAmount) {
         var index = Math.floor(Math.random() * options.length)
         if (indexes.indexOf(index) > -1) continue
         indexes.push(index)
@@ -50,7 +50,7 @@ export default {
       if(this.reloading.state !== STATES.DEFAULT) return
 
       this.reloading.state = STATES.LOADING
-      this.selectOptions()
+      this.generateOptions()
       this.reloading.state = STATES.SUCCESS
       this.reloading.message = 'reload成功'
     }

--- a/components/TopicBrowser.vue
+++ b/components/TopicBrowser.vue
@@ -6,7 +6,7 @@
 
 <script>
 export default {
-  props: ['limit', 'topics', 'selectedTopics', 'mutable'],
+  props: ['limit', 'selectedTopics', 'topics', 'mutable'],
   data() {
     return {
       internalTopics: this.generateInternalTopics()


### PR DESCRIPTION
### DONE
- 可限制從所有圖片 (`options`) 中，僅取某數目 (`amount`) 的圖片讓使用者選取
- 使用者可從 `internalOptions` 中選取某數目 (`limit`) 的圖片，並更新 `selectedOptions` 回傳至 parent component


### UNDONE
- reload btn 的css

### TBD
- 所有圖片選項們從common-assets/images 的某資料夾路徑下直接讀取所有圖檔(?)
- 其實coverImage應該只有一個對不對lol 如果選取多個這個功能要被砍掉我再改