### PR TITLE
call stats api

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -173,3 +173,20 @@ export function getMatch(gameSlug, matchSlug) {
 export function getParties() {
   return coreInstance.get('/c0ngress/parties')
 }
+
+// ask - game - statistics
+export function getReviewCount(gameSlug) {
+  return coreInstance.get('/ask/games/' + gameSlug + '/stats/review_count')
+}
+
+export function getReviewAverage(gameSlug) {
+  return coreInstance.get('/ask/games/' + gameSlug + '/stats/guest_review_average')
+}
+
+export function getReviewAverageByTopic(gameSlug) {
+  return coreInstance.get('/ask/games/' + gameSlug + '/stats/guest_topic_review_average')
+}
+
+export function getAnsweredAmt(gameSlug) {
+  return coreInstance.get('/ask/games/' + gameSlug + '/stats/guest_answered_questions')
+}


### PR DESCRIPTION
ref: https://docs.core.watchout.tw/ask/stats

### DONE
- `getReviewCount ` - 拿到對該game的評分人數
- `getReviewAverage ` - 拿到不同player對應的平均評分
- `getReviewAverageByTopic ` - 拿到不同player在不同topic下的平均評分
- `getAnsweredAmt ` - 拿到不同player對應的被assign題目數與已答題目數

> 其實不知道放在這對不對，要放別的地方請再跟我說～～～