### PR TITLE
加回 scrapeMetadata，但不 fetch 新的 meta 資訊

### DIFF
--- a/lib/bunko.js
+++ b/lib/bunko.js
@@ -206,7 +206,7 @@ export async function getDataOnReferences(references) {
     } else if(ref.type === 'collection') {
       promise = firestore.bunko.getCollection(ref.id, true)
     } else if(['http', 'https'].includes(ref.type)) {
-      // promise = firestore.watchout.scrapeMetadata(ref.permalink)
+      promise = firestore.watchout.scrapeMetadata(ref.permalink)
     }
     return promise
   }))

--- a/lib/firestore.js
+++ b/lib/firestore.js
@@ -1151,55 +1151,67 @@ async function scrapeMetadata(url, cacheFirst = true) {
       }
     }
   }
-  if(entry && upToDate) {
-    console.info('Metadata up to date')
-  } else {
-    if(!upToDate) {
-      console.info('Metadata out of date')
-    }
-    console.info('Fetch metadata from source', url)
-    let head = null
-    let title = null
-    let titles = null
-    let image = null
-    let images = null
-    let descriptions = null
-    try {
-      let response = await scraper.get(url)
-      let html = response.data
-      html = html.replace(/(?:\r\n|\r|\n)/g, '')
-      head = html.match(/<head>(.*)<\/head>/)
-      head = Array.isArray(head) ? head[1] : null
-    } catch(error) {
-      console.error(error.message)
-    }
-    if(head) {
-      title = head.match(/<\s*title[^>]*>(.*)<\/title>/)
-      title = Array.isArray(title) ? decode(title[1]) : null
-      title = title ? title : url
-      titles = parseMetaContent('title', head)
-      descriptions = parseMetaContent('description', head)
-      images = parseMetaContent('image', head)
-      image = images['twitter:image'] ? images['twitter:image'] : (images['og:image'] ? images['og:image'] : null)
-    }
-
-    let newEntry = {
-      url,
-      title,
-      titles,
-      image,
-      images,
-      descriptions
-    }
-    if(entry && !upToDate) {
-      console.info('Update metadata', id)
-      entry = await updateMetadata(id, newEntry)
-    } else {
-      console.info('Add metadata', id)
-      entry = await addMetadata(id, newEntry)
-    }
+  // This section is HOTFIX, please FIXME later
+  let newEntry = {
+    url,
+    title: null,
+    titles: null,
+    image: null,
+    images: null,
+    descriptions: null
   }
-  return entry
+  return entry ? entry : newEntry
+  // section end.
+
+  // if(entry && upToDate) {
+  //   console.info('Metadata up to date')
+  // } else {
+  //   if(!upToDate) {
+  //     console.info('Metadata out of date')
+  //   }
+  //   console.info('Fetch metadata from source', url)
+  //   let head = null
+  //   let title = null
+  //   let titles = null
+  //   let image = null
+  //   let images = null
+  //   let descriptions = null
+  //   try {
+  //     let response = await scraper.get(url)
+  //     let html = response.data
+  //     html = html.replace(/(?:\r\n|\r|\n)/g, '')
+  //     head = html.match(/<head>(.*)<\/head>/)
+  //     head = Array.isArray(head) ? head[1] : null
+  //   } catch(error) {
+  //     console.error(error.message)
+  //   }
+  //   if(head) {
+  //     title = head.match(/<\s*title[^>]*>(.*)<\/title>/)
+  //     title = Array.isArray(title) ? decode(title[1]) : null
+  //     title = title ? title : url
+  //     titles = parseMetaContent('title', head)
+  //     descriptions = parseMetaContent('description', head)
+  //     images = parseMetaContent('image', head)
+  //     image = images['twitter:image'] ? images['twitter:image'] : (images['og:image'] ? images['og:image'] : null)
+  //   }
+
+  //   let newEntry = {
+  //     url,
+  //     title,
+  //     titles,
+  //     image,
+  //     images,
+  //     descriptions
+  //   }
+  //   if(entry && !upToDate) {
+  //     console.info('Update metadata', id)
+  //     entry = await updateMetadata(id, newEntry)
+  //   } else {
+  //     console.info('Add metadata', id)
+  //     entry = await addMetadata(id, newEntry)
+  //   }
+  // }
+  // return entry
 }
 
 export const watchout = {


### PR DESCRIPTION
由於大量 fetch 外部連結的 meta 資訊，會容易造成 firebase exceed auth limit 的錯誤，但此錯誤為 firebase 內部計數，並不是公開的可購買數量，是以不透明且無法避免。而目前暫無新增外部連結 link 的需求，先開放舊的 meta 資訊使用，可減少大量 fetch meta。