### PR TITLE
Use double equal for comparing authorObj

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
   ],
   rules: {
     'arrow-parens': ['error', 'as-needed'],
+    'eqeqeq': 0,
     'keyword-spacing': [
       'error',
       {

--- a/components/ReferencePreview.vue
+++ b/components/ReferencePreview.vue
@@ -414,7 +414,7 @@ export default {
   methods: {
     cachedAuthorPersona(personaID) {
       let author = this.cachedAuthors
-        ? this.cachedAuthors.find(author => author.persona === personaID)
+        ? this.cachedAuthors.find(author => author.persona == personaID)
         : null
       return author ? author.personaObj : null
     }

--- a/components/comp/DocHeader.vue
+++ b/components/comp/DocHeader.vue
@@ -78,7 +78,7 @@ export default {
   },
   methods: {
     cachedAuthorByPersona(personaID) {
-      return this.cachedAuthors && this.cachedAuthors.find(author => author.persona === personaID) ? this.cachedAuthors.find(author => author.persona === personaID) : { personaObj: {} }
+      return this.cachedAuthors && this.cachedAuthors.find(author => author.persona == personaID) ? this.cachedAuthors.find(author => author.persona == personaID) : { personaObj: {} }
     },
     // FIXME: workaround of i18n
     getAuthorTypeLabel(type) {


### PR DESCRIPTION
Since this value is now integer in Core(MySQL) but was a string in Firebase, we use double equal instead of triple equal here.